### PR TITLE
fix: 메인화면 Footer 후원 버튼 클릭 불가 문제 수정 (#4)

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -24,7 +24,7 @@ const Footer = () => {
   };
 
   return (
-      <footer className="bg-black text-green-300 font-mono py-8 border-t border-green-900/40">
+      <footer className="bg-black text-green-300 font-mono py-8 border-t border-green-900/40 relative z-10">
         <div className="container mx-auto px-4 text-center text-sm space-y-2">
           <p>&gt; 개발자의, 개발자에 의한, 개발자를 위한 핑계 시스템</p>
           <p>&gt; Made with ❤️ by soheejjang0912@gmail.com</p>


### PR DESCRIPTION
## 📄 변경 내용
### 🐛 버그 수정
- 메인 페이지에서 **Footer의 ☕ 카카오페이 후원하기 버튼**이 클릭되지 않던 문제 해결
  - **원인**: 홈 화면의 `fixed` 배경 레이어가 클릭 이벤트를 가로챔
  - **해결**: `Footer` root에 `relative z-10` 속성을 추가하여 클릭 영역 확보

---

## ✅ 체크리스트
- [x] 메인 페이지에서 후원 버튼 클릭 시 정상 동작 확인  
- [x] 다른 페이지에서 후원 버튼 클릭 시 기존 동작 유지 확인  
- [x] 스타일 및 레이아웃에 부작용 없는지 확인  

---

## 🔗 관련 이슈
- Closes #4
