### PR TITLE
fix(api): 메인 페이지 통계 API 불일치 수정

### DIFF
--- a/app/api/database-stats/route.ts
+++ b/app/api/database-stats/route.ts
@@ -1,29 +1,22 @@
-import { createServerClient } from "@supabase/ssr";
+import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
+
+export const dynamic = 'force-dynamic';
 
 export async function GET() {
   const logs: string[] = [];
   logs.push("--- /api/database-stats endpoint hit ---");
   try {
-    logs.push("Attempting to create Supabase client with SERVICE_ROLE_KEY...");
-    const supabase = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-      {
-        cookies: {
-          getAll: () => [],
-          setAll: () => {},
-        },
-      }
-    );
+    logs.push("Attempting to create Supabase client...");
+    const supabase = await createClient();
     logs.push("Supabase client created successfully.");
 
     // Get total count of APPROVED excuses
     logs.push("Fetching total count of APPROVED excuses...");
     const { count: totalExcuses, error: countError } = await supabase
-      .from("excuses")
-      .select("*", { count: "exact", head: true })
-      .eq("is_approved", true); // Filter by approved
+        .from("excuses")
+        .select("*", { count: "exact", head: true })
+        .eq("is_approved", true); // Filter by approved
 
     if (countError) {
       logs.push(`DATABASE ERROR (count): ${JSON.stringify(countError)}`);
@@ -34,9 +27,9 @@ export async function GET() {
     // Get total usage count (sum of all usage_count for APPROVED excuses)
     logs.push("Fetching usage data for APPROVED excuses...");
     const { data: usageData, error: usageError } = await supabase
-      .from("excuses")
-      .select("usage_count")
-      .eq("is_approved", true); // Filter by approved
+        .from("excuses")
+        .select("usage_count")
+        .eq("is_approved", true); // Filter by approved
 
     if (usageError) {
       logs.push(`DATABASE ERROR (usage): ${JSON.stringify(usageError)}`);
@@ -44,7 +37,7 @@ export async function GET() {
     }
 
     const totalUsage =
-      usageData?.reduce((sum, item) => sum + (item.usage_count || 0), 0) || 0;
+        usageData?.reduce((sum, item) => sum + (item.usage_count || 0), 0) || 0;
     logs.push(`Total APPROVED usage calculated: ${totalUsage}`);
 
     return NextResponse.json({
@@ -56,13 +49,13 @@ export async function GET() {
     logs.push(`UNCAUGHT ERROR in /api/database-stats: ${e.message}`);
     console.error("Error fetching database stats:", { logs, error: e });
     return NextResponse.json(
-      {
-        error: "Failed to fetch database stats",
-        totalExcuses: 0,
-        totalUsage: 0,
-        server_logs: logs, // Include logs in error response
-      },
-      { status: 500 }
+        {
+          error: "Failed to fetch database stats",
+          totalExcuses: 0,
+          totalUsage: 0,
+          server_logs: logs, // Include logs in error response
+        },
+        { status: 500 }
     );
   }
 }


### PR DESCRIPTION

## 📝 개요
- 메인 페이지의 통계(전체 핑계 수, 총 사용량)가 실제 DB와 맞지 않던 문제 해결  
- 랭킹 페이지는 영향 없음

## 🔧 변경 사항
1. **/api/database-stats**
   - `createServerClient` → `@/lib/supabase/server`의 `createClient()`로 수정
   - 세션/쿠키 컨텍스트 정상 적용
2. **/api/database-stats**
   - `export const dynamic = 'force-dynamic';` 추가 → 캐싱 방지, 항상 최신 데이터 반환

## 🔗 관련 이슈
- Closes #7

## ✅ 테스트
- [x] 메인 페이지 통계 값이 DB 값과 정확히 일치하는지 확인  
- [x] DB 데이터 변경 시 즉시 반영되는지 확인  
- [x] 랭킹 페이지가 기존과 동일하게 정상 동작하는지 확인
