### PR TITLE
fix(api): API 라우트를 동적 처리로 강제하여 빌드 에러 해결 (#9)

### DIFF
--- a/app/api/admin/pending-excuses/route.ts
+++ b/app/api/admin/pending-excuses/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server"
 import { createServerClient } from "@/lib/supabase/server"
 
+// 동적 라우트 강제 + 캐시 비활성화
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
+
 export async function GET() {
   try {
     const supabase = await createServerClient()

--- a/app/api/approved-excuses/route.ts
+++ b/app/api/approved-excuses/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import { createServerClient } from "@/lib/supabase/server";
 
+// 동적 라우트 강제 + 캐시 비활성화
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
+
 export async function GET() {
   console.log("--- /api/approved-excuses endpoint hit ---");
   try {

--- a/app/api/excuse-stats/route.ts
+++ b/app/api/excuse-stats/route.ts
@@ -1,6 +1,11 @@
 import { createClient } from "@/lib/supabase/server"
 import { type NextRequest, NextResponse } from "next/server"
 
+// 동적 라우트 강제 + 캐시 비활성화
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
+
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)

--- a/app/api/rankings/route.ts
+++ b/app/api/rankings/route.ts
@@ -1,6 +1,11 @@
 import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
 
+// 동적 라우트 강제 + 캐시 비활성화
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
+
 export async function GET() {
   const logs: string[] = [];
   logs.push("--- /api/rankings endpoint hit ---");


### PR DESCRIPTION
## 📄 변경 내용
### 🐛 Dynamic server usage 에러 해결
- `/api/admin/pending-excuses` 라우트에 `dynamic`, `revalidate`, `fetchCache` 설정 추가  
- `/api/approved-excuses` 라우트에 동일 설정 추가  
- `/api/excuse-stats` 라우트에 동일 설정 추가  
- `/api/rankings` 라우트에 동일 설정 추가  

---

## ✅ 체크리스트
- [x] `npm run build` 시 더 이상 Dynamic server usage 에러 발생하지 않음  
- [x] 해당 API 라우트가 빌드 로그에서 `ƒ (Dynamic)`으로 표시됨  
- [x] 기존 API 동작 정상 확인  

---

## 🔗 관련 이슈
- Closes #9
